### PR TITLE
WIP: Upgrade to latest nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(io)]
+#![feature(old_io, env)]
 
 use std::old_io::process::{Command, ProcessExit, StdioContainer};
-use std::os;
+use std::env;
 
 fn main() {
-    let out_dir = os::getenv("OUT_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").unwrap();
     let result = Command::new("make")
         .args(&["-f", "makefile.cargo"])
         .stdout(StdioContainer::InheritFd(1))

--- a/codecs/vorbis.rs
+++ b/codecs/vorbis.rs
@@ -15,6 +15,7 @@ use libc::{c_float, c_int};
 use std::mem;
 use std::ptr;
 use std::slice;
+use std::marker::PhantomData;
 
 pub struct VorbisInfo {
     info: Box<ffi::vorbis_info>,
@@ -126,6 +127,7 @@ impl VorbisDspState {
                 (*self.state.vi).channels
             },
             samples: result,
+            phantom: PhantomData,
         })
     }
 
@@ -201,6 +203,7 @@ pub struct Pcm<'a> {
     pcm: *mut *mut c_float,
     channels: c_int,
     samples: c_int,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Pcm<'a> {
@@ -212,7 +215,7 @@ impl<'a> Pcm<'a> {
         unsafe {
             let buffer = (*self.pcm).offset(channel as isize);
             mem::transmute::<&[c_float],
-                             &'a [c_float]>(slice::from_raw_mut_buf(&buffer,
+                             &'a [c_float]>(slice::from_raw_parts_mut(buffer,
                                                                     self.samples as usize))
         }
     }

--- a/codecs/vpx.rs
+++ b/codecs/vpx.rs
@@ -17,6 +17,7 @@ use libc::{c_int, c_long, c_uint};
 use std::ptr;
 use std::slice;
 use std::u32;
+use std::marker::PhantomData;
 
 pub struct VpxCodecIface {
     iface: *mut ffi::vpx_codec_iface_t,
@@ -93,6 +94,7 @@ impl VpxCodec {
         } else {
             Some(VpxCodecIter {
                 iter: iter_ptr,
+                phantom: PhantomData,
             })
         };
         if !image.is_null() {
@@ -107,6 +109,7 @@ impl VpxCodec {
 
 pub struct VpxCodecIter<'a> {
     iter: ffi::vpx_codec_iter_t,
+    phantom: PhantomData<&'a u8>,
 }
 
 pub struct VpxImage {
@@ -151,7 +154,7 @@ impl VpxImage {
         assert!(index < 4);
         unsafe {
             let len = (self.stride(index) as c_uint) * (*self.image).h;
-            slice::from_raw_mut_buf(&(*self.image).planes[index as usize], len as usize)
+            slice::from_raw_parts_mut((*self.image).planes[index as usize], len as usize)
         }
     }
 

--- a/containers/ogg.rs
+++ b/containers/ogg.rs
@@ -15,6 +15,7 @@ use libc::{c_char, c_int, c_long};
 use std::i32;
 use std::mem;
 use std::slice;
+use std::marker::PhantomData;
 
 pub struct SyncState {
     state: ffi::ogg_sync_state,
@@ -44,7 +45,7 @@ impl SyncState {
         unsafe {
             let ptr = ffi::ogg_sync_buffer(&mut self.state, size);
             assert!(!ptr.is_null());
-            mem::transmute::<&mut [c_char],&'a mut [u8]>(slice::from_raw_mut_buf(&ptr,
+            mem::transmute::<&mut [c_char],&'a mut [u8]>(slice::from_raw_parts_mut(ptr,
                                                                                  size as usize))
         }
     }
@@ -127,12 +128,14 @@ impl StreamState {
         }
         Packet {
             packet: packet,
+            phantom: PhantomData,
         }
     }
 }
 
 pub struct Packet<'a> {
     packet: ffi::ogg_packet,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Packet<'a> {
@@ -153,6 +156,7 @@ impl<'a> Packet<'a> {
                 granulepos: 0,
                 packetno: packet_number,
             },
+            phantom: PhantomData,
         }
     }
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -21,11 +21,9 @@ git = "https://github.com/tomaka/clock_ticks.git"
 [dependencies.sdl2]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
 
 [dependencies.sdl2-sys]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
 path = "sdl2-sys"
 

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, collections, core, io, libc, std_misc, unsafe_destructor)]
+#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor)]
 
 extern crate alloc;
 extern crate libc;

--- a/playback.rs
+++ b/playback.rs
@@ -18,6 +18,7 @@ use libc::{c_int, c_long};
 use std::iter;
 use std::mem;
 use std::num::SignedInt;
+use std::marker::PhantomData;
 
 /// A simple video/audio player.
 pub struct Player<'a> {
@@ -36,6 +37,7 @@ pub struct Player<'a> {
     last_frame_presentation_time: Option<Timestamp>,
     /// The time at which the next frame is to be played.
     next_frame_presentation_time: Option<Timestamp>,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Player<'a> {
@@ -83,6 +85,7 @@ impl<'a> Player<'a> {
             frame_delay: None,
             last_frame_presentation_time: None,
             next_frame_presentation_time: None,
+            phantom: PhantomData,
         }
     }
 
@@ -231,7 +234,7 @@ impl<'a> Player<'a> {
     pub fn next_frame_presentation_time(&self) -> Option<Timestamp> {
         self.next_frame_presentation_time
     }
-    
+
     /// Retrieves the decoded frame data and advances to the next frame.
     pub fn advance(&mut self) -> Result<DecodedFrame,()> {
         // Determine the frame delay, if possible.


### PR DESCRIPTION
So I know this library is supposed to be pegged to the version of Rust that Servo uses, but I thought maybe it would be worth having a branch that is updated separately?

Changes are broken up into a few logical commits. The last two are just trivial fixups, but the first two are important. 

The first adds PhantomData to bind the variance of the otherwise unused lifetimes. I don't believe master is actually valid without this change (s/PhantomData/ContravariantLifetime should be the equivalent servo-version-friendly change), as the lifetimes are otherwise bivariant, as I understand it.

This actually revealed a lifetime bug in the code that the second patch attempts to resolve. I say attempts because I'm not 100% sure what semantics you were going for. I went for the one that seemed to match up with usage.

TBD: updating the example code. This requires updating the sdl2 dependencies, which are currently hardcoded to some commit. Need to look into what the appropriate version to update to is. Any insight on this matter would be appreciated.
