### PR TITLE
WIP Refactor Track to have a cleaner type-safe API

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(io)]
+#![feature(old_io, env)]
 
 use std::old_io::process::{Command, ProcessExit, StdioContainer};
-use std::os;
+use std::env;
 
 fn main() {
-    let out_dir = os::getenv("OUT_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").unwrap();
     let result = Command::new("make")
         .args(&["-f", "makefile.cargo"])
         .stdout(StdioContainer::InheritFd(1))

--- a/build.rs
+++ b/build.rs
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(old_io, env)]
-
-use std::old_io::process::{Command, ProcessExit, StdioContainer};
+use std::process::{Command, Stdio};
 use std::env;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let result = Command::new("make")
         .args(&["-f", "makefile.cargo"])
-        .stdout(StdioContainer::InheritFd(1))
-        .stderr(StdioContainer::InheritFd(2))
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
         .status()
         .unwrap();
-    assert_eq!(result, ProcessExit::ExitStatus(0));
+    assert!(result.success());
     println!("cargo:rustc-flags=-L native={}", out_dir);
 }
 

--- a/codecs/vorbis.rs
+++ b/codecs/vorbis.rs
@@ -15,6 +15,7 @@ use libc::{c_float, c_int};
 use std::mem;
 use std::ptr;
 use std::slice;
+use std::marker::PhantomData;
 
 pub struct VorbisInfo {
     info: Box<ffi::vorbis_info>,
@@ -126,6 +127,7 @@ impl VorbisDspState {
                 (*self.state.vi).channels
             },
             samples: result,
+            phantom: PhantomData,
         })
     }
 
@@ -201,6 +203,7 @@ pub struct Pcm<'a> {
     pcm: *mut *mut c_float,
     channels: c_int,
     samples: c_int,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Pcm<'a> {
@@ -212,7 +215,7 @@ impl<'a> Pcm<'a> {
         unsafe {
             let buffer = (*self.pcm).offset(channel as isize);
             mem::transmute::<&[c_float],
-                             &'a [c_float]>(slice::from_raw_mut_buf(&buffer,
+                             &'a [c_float]>(slice::from_raw_parts_mut(buffer,
                                                                     self.samples as usize))
         }
     }

--- a/codecs/vpx.rs
+++ b/codecs/vpx.rs
@@ -17,6 +17,7 @@ use libc::{c_int, c_long, c_uint};
 use std::ptr;
 use std::slice;
 use std::u32;
+use std::marker::PhantomData;
 
 pub struct VpxCodecIface {
     iface: *mut ffi::vpx_codec_iface_t,
@@ -93,6 +94,7 @@ impl VpxCodec {
         } else {
             Some(VpxCodecIter {
                 iter: iter_ptr,
+                phantom: PhantomData,
             })
         };
         if !image.is_null() {
@@ -107,6 +109,7 @@ impl VpxCodec {
 
 pub struct VpxCodecIter<'a> {
     iter: ffi::vpx_codec_iter_t,
+    phantom: PhantomData<&'a u8>,
 }
 
 pub struct VpxImage {
@@ -151,7 +154,7 @@ impl VpxImage {
         assert!(index < 4);
         unsafe {
             let len = (self.stride(index) as c_uint) * (*self.image).h;
-            slice::from_raw_mut_buf(&(*self.image).planes[index as usize], len as usize)
+            slice::from_raw_parts_mut((*self.image).planes[index as usize], len as usize)
         }
     }
 

--- a/container.rs
+++ b/container.rs
@@ -17,6 +17,7 @@ use timing::Timestamp;
 use videodecoder;
 
 use libc::{c_double, c_int, c_long};
+use std::str;
 
 pub trait ContainerReader {
     fn track_count(&self) -> u16;
@@ -25,32 +26,32 @@ pub trait ContainerReader {
 
     fn debug(&self, number: c_long) -> String {
         use std::fmt::Write; // Shim for `writeln` being duck-typed during old_io transition
-        
-        let track = self.track_by_number(index);
+
+        let track = self.track_by_number(number);
 
         let mut result = format!("Track {}\n", track.number());
         if let Some(codec) = track.codec() {
             if let Ok(codec) = str::from_utf8(&codec) {
-                writeln!(&mut result, "  Codec: {}", codec);
+                writeln!(&mut result, "  Codec: {}", codec).unwrap();
             }
         }
 
         match track.track_type() {
             TrackType::Video(video_track) => {
-                writeln!(&mut result, " Type: Video");
-                writeln!(&mut result, "  Width: {}", video_track.width());
-                writeln!(&mut result, "  Height: {}", video_track.height());
-                writeln!(&mut result, "  Frame Rate: {}", video_track.frame_rate());
+                writeln!(&mut result, " Type: Video").unwrap();
+                writeln!(&mut result, "  Width: {}", video_track.width()).unwrap();
+                writeln!(&mut result, "  Height: {}", video_track.height()).unwrap();
+                writeln!(&mut result, "  Frame Rate: {}", video_track.frame_rate()).unwrap();
                 if let Some(cluster_count) = video_track.cluster_count() {
-                    writeln!(&mut result, "  Cluster Count: {}", cluster_count);
+                    writeln!(&mut result, "  Cluster Count: {}", cluster_count).unwrap();
                 }
             }
             TrackType::Audio(audio_track) => {
-                writeln!(&mut result, " Type: Audio");
-                writeln!(&mut result, "  Channels: {}", audio_track.channels());
-                writeln!(&mut result, "  Rate: {}", audio_track.sampling_rate());
+                writeln!(&mut result, " Type: Audio").unwrap();
+                writeln!(&mut result, "  Channels: {}", audio_track.channels()).unwrap();
+                writeln!(&mut result, "  Rate: {}", audio_track.sampling_rate()).unwrap();
                 if let Some(cluster_count) = audio_track.cluster_count() {
-                    writeln!(&mut result, "  Cluster Count: {}", cluster_count);
+                    writeln!(&mut result, "  Cluster Count: {}", cluster_count).unwrap();
                 }
             }
             _ => {}

--- a/containers/gif.rs
+++ b/containers/gif.rs
@@ -24,7 +24,8 @@ use std::cell::RefCell;
 use std::i32;
 use std::mem;
 use std::num::FromPrimitive;
-use std::old_io::{BufReader, BufWriter, SeekStyle};
+use std::old_io::{BufReader, BufWriter};
+use std::io::SeekFrom;
 use std::ptr;
 use std::slice;
 use std::marker::PhantomData;
@@ -58,7 +59,7 @@ impl FileType {
                 file: file,
                 next_record_byte_offset: 0,
             };
-            file.next_record_byte_offset = file.reader().tell().unwrap();
+            file.next_record_byte_offset = file.reader().seek(SeekFrom::Current(0)).unwrap();
             Ok(file)
         } else {
             Err(error)
@@ -91,7 +92,7 @@ impl FileType {
     /// records or false if we're done.
     pub fn read_record(&mut self) -> Result<bool,()> {
         let next_record_byte_offset = self.next_record_byte_offset;
-        self.reader().seek(next_record_byte_offset as i64, SeekStyle::SeekSet).unwrap();
+        self.reader().seek(SeekFrom::Start(next_record_byte_offset)).unwrap();
 
         let mut record_type = 0;
         unsafe {
@@ -168,7 +169,7 @@ impl FileType {
             _ => return Ok(false),
         }
 
-        self.next_record_byte_offset = self.reader().tell().unwrap();
+        self.next_record_byte_offset = self.reader().seek(SeekFrom::Current(0)).unwrap();
         Ok(true)
     }
 

--- a/containers/mkv.rs
+++ b/containers/mkv.rs
@@ -18,11 +18,15 @@ use videodecoder;
 use libc::{c_char, c_double, c_int, c_long, c_longlong, c_uchar, c_ulong, c_void, size_t};
 use std::ffi::CStr;
 use std::mem;
-use std::num::FromPrimitive;
 use std::old_io::SeekStyle;
 use std::ptr;
 use std::slice;
 use std::marker::PhantomData;
+
+const VIDEO_TRACK_TYPE: i32 = 1;
+const AUDIO_TRACK_TYPE: i32 = 2;
+// const SUBTITLE_TRACK_TYPE: i32 = 0x11;
+// const METADATA_TRACK_TYPE: i32 = 0x21;
 
 pub struct MkvReader {
     reader: WebmIMkvReaderRef,
@@ -274,10 +278,33 @@ pub struct Track<'a> {
 }
 
 impl<'a> Track<'a> {
-    pub fn track_type(&self) -> TrackType {
-        unsafe {
-            FromPrimitive::from_i32(WebmTrackGetType(self.track) as i32).unwrap()
+    pub fn track_type(self) -> TrackType<'a> {
+        let track_type = unsafe { WebmTrackGetType(self.track) as i32 };
+        match track_type {
+            VIDEO_TRACK_TYPE => TrackType::Video(VideoTrack {
+                track: unsafe {
+                    mem::transmute::<_,WebmVideoTrackRef>(self.track)
+                },
+                phantom: PhantomData,
+            }),
+            AUDIO_TRACK_TYPE => TrackType::Audio(AudioTrack {
+                track: unsafe {
+                    mem::transmute::<_,WebmAudioTrackRef>(self.track)
+                },
+                phantom: PhantomData,
+            }),
+            _ => TrackType::Other(self),
         }
+    }
+
+    pub fn is_video(&self) -> bool {
+        let track_type = unsafe { WebmTrackGetType(self.track) as i32 };
+        track_type == VIDEO_TRACK_TYPE
+    }
+
+    pub fn is_audio(&self) -> bool {
+        let track_type = unsafe { WebmTrackGetType(self.track) as i32 };
+        track_type == AUDIO_TRACK_TYPE
     }
 
     pub fn number(&self) -> c_long {
@@ -299,30 +326,6 @@ impl<'a> Track<'a> {
         unsafe {
             let ptr = WebmTrackGetCodecPrivate(self.track, &mut size);
             mem::transmute::<&[u8],&'b [u8]>(slice::from_raw_parts(ptr, size as usize))
-        }
-    }
-
-    pub fn as_video_track(&self) -> VideoTrack<'a> {
-        if self.track_type() != TrackType::Video {
-            panic!("Track::as_video_track(): not a video track!")
-        }
-        VideoTrack {
-            track: unsafe {
-                mem::transmute::<_,WebmVideoTrackRef>(self.track)
-            },
-            phantom: PhantomData,
-        }
-    }
-
-    pub fn as_audio_track(&self) -> AudioTrack<'a> {
-        if self.track_type() != TrackType::Audio {
-            panic!("Track::as_audio_track(): not an audio track!")
-        }
-        AudioTrack {
-            track: unsafe {
-                mem::transmute::<_,WebmAudioTrackRef>(self.track)
-            },
-            phantom: PhantomData,
         }
     }
 }
@@ -602,12 +605,10 @@ impl<'a> BlockFrame<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
-pub enum TrackType {
-    Video = 1,
-    Audio = 2,
-    Subtitle = 0x11,
-    Metadata = 0x21,
+pub enum TrackType<'a> {
+    Video(VideoTrack<'a>),
+    Audio(AudioTrack<'a>),
+    Other(Track<'a>),
 }
 
 // Implementation of the abstract `ContainerReader` interface
@@ -666,14 +667,32 @@ struct TrackImpl<'a> {
     reader: &'a MkvReader,
 }
 
-impl<'a> container::Track for TrackImpl<'a> {
-    fn track_type(&self) -> container::TrackType {
-        match self.track.track_type() {
-            TrackType::Video => container::TrackType::Video,
-            TrackType::Audio => container::TrackType::Audio,
-            _ => container::TrackType::Other,
+impl<'a> container::Track<'a> for TrackImpl<'a> {
+    fn track_type(self: Box<Self>) -> container::TrackType<'a> {
+        let segment = self.segment;
+        let reader = self.reader;
+        let track = self.track;
+        match track.track_type() {
+            TrackType::Video(track) => container::TrackType::Video(Box::new(VideoTrackImpl {
+                track: track,
+                segment: segment,
+                reader: reader,
+            }) as Box<container::VideoTrack<'a> + 'a>),
+            TrackType::Audio(track) => container::TrackType::Audio(Box::new(AudioTrackImpl {
+                track: track,
+                segment: segment,
+                reader: reader,
+            }) as Box<container::AudioTrack<'a> + 'a>),
+            TrackType::Other(track) => container::TrackType::Other(Box::new(TrackImpl {
+                track: track,
+                segment: segment,
+                reader: reader,
+            }) as Box<container::Track<'a> + 'a>),
         }
     }
+    fn is_video(&self) -> bool { self.track.is_video() }
+    fn is_audio(&self) -> bool { self.track.is_audio() }
+
 
     fn cluster_count(&self) -> Option<c_int> {
         Some(self.segment.count() as c_int)
@@ -690,28 +709,6 @@ impl<'a> container::Track for TrackImpl<'a> {
     fn cluster<'b>(&'b self, cluster_index: i32) -> Result<Box<container::Cluster + 'b>,()> {
         Ok(get_cluster(cluster_index, self.segment, self.reader))
     }
-
-    fn as_video_track<'b>(&'b self) -> Result<Box<container::VideoTrack + 'b>,()> {
-        if self.track.track_type() != TrackType::Video {
-            return Err(())
-        }
-        Ok(Box::new(VideoTrackImpl {
-            track: self.track.as_video_track(),
-            segment: self.segment,
-            reader: self.reader,
-        }) as Box<container::VideoTrack + 'b>)
-    }
-
-    fn as_audio_track<'b>(&'b self) -> Result<Box<container::AudioTrack + 'b>,()> {
-        if self.track.track_type() != TrackType::Audio {
-            return Err(())
-        }
-        Ok(Box::new(AudioTrackImpl {
-            track: self.track.as_audio_track(),
-            segment: self.segment,
-            reader: self.reader,
-        }) as Box<container::AudioTrack + 'b>)
-    }
 }
 
 #[derive(Clone)]
@@ -721,10 +718,13 @@ struct VideoTrackImpl<'a> {
     reader: &'a MkvReader,
 }
 
-impl<'a> container::Track for VideoTrackImpl<'a> {
-    fn track_type(&self) -> container::TrackType {
-        container::TrackType::Video
+impl<'a> container::Track<'a> for VideoTrackImpl<'a> {
+    fn track_type(self: Box<Self>) -> container::TrackType<'a> {
+        container::TrackType::Video(self as Box<container::VideoTrack<'a> + 'a>)
     }
+
+    fn is_video(&self) -> bool { true }
+    fn is_audio(&self) -> bool { false }
 
     fn cluster_count(&self) -> Option<c_int> {
         Some(self.segment.count() as c_int)
@@ -734,6 +734,7 @@ impl<'a> container::Track for VideoTrackImpl<'a> {
         self.track.as_track().number()
     }
 
+
     fn cluster<'b>(&'b self, cluster_index: i32) -> Result<Box<container::Cluster + 'b>,()> {
         Ok(get_cluster(cluster_index, self.segment, self.reader))
     }
@@ -741,17 +742,9 @@ impl<'a> container::Track for VideoTrackImpl<'a> {
     fn codec(&self) -> Option<Vec<u8>> {
         codec_id_to_fourcc(self.track.as_track().codec_id())
     }
-
-    fn as_video_track<'b>(&'b self) -> Result<Box<container::VideoTrack + 'b>,()> {
-        Ok(Box::new((*self).clone()) as Box<container::VideoTrack + 'b>)
-    }
-
-    fn as_audio_track<'b>(&'b self) -> Result<Box<container::AudioTrack + 'b>,()> {
-        Err(())
-    }
 }
 
-impl<'a> container::VideoTrack for VideoTrackImpl<'a> {
+impl<'a> container::VideoTrack<'a> for VideoTrackImpl<'a> {
     fn width(&self) -> u16 {
         self.track.width() as u16
     }
@@ -781,10 +774,13 @@ struct AudioTrackImpl<'a> {
     reader: &'a MkvReader,
 }
 
-impl<'a> container::Track for AudioTrackImpl<'a> {
-    fn track_type(&self) -> container::TrackType {
-        container::TrackType::Audio
+impl<'a> container::Track<'a> for AudioTrackImpl<'a> {
+    fn track_type(self: Box<Self>) -> container::TrackType<'a> {
+        container::TrackType::Audio(self as Box<container::AudioTrack<'a> + 'a>)
     }
+
+    fn is_video(&self) -> bool { false }
+    fn is_audio(&self) -> bool { true }
 
     fn cluster_count(&self) -> Option<c_int> {
         Some(self.segment.count() as c_int)
@@ -801,17 +797,9 @@ impl<'a> container::Track for AudioTrackImpl<'a> {
     fn codec(&self) -> Option<Vec<u8>> {
         codec_id_to_fourcc(self.track.as_track().codec_id())
     }
-
-    fn as_video_track<'b>(&'b self) -> Result<Box<container::VideoTrack + 'b>,()> {
-        Err(())
-    }
-
-    fn as_audio_track<'b>(&'b self) -> Result<Box<container::AudioTrack + 'b>,()> {
-        Ok(Box::new((*self).clone()) as Box<container::AudioTrack + 'b>)
-    }
 }
 
-impl<'a> container::AudioTrack for AudioTrackImpl<'a> {
+impl<'a> container::AudioTrack<'a> for AudioTrackImpl<'a> {
     fn sampling_rate(&self) -> c_double {
         self.track.sampling_rate()
     }

--- a/containers/mkv.rs
+++ b/containers/mkv.rs
@@ -281,18 +281,22 @@ impl<'a> Track<'a> {
     pub fn track_type(self) -> TrackType<'a> {
         let track_type = unsafe { WebmTrackGetType(self.track) as i32 };
         match track_type {
-            VIDEO_TRACK_TYPE => TrackType::Video(VideoTrack {
-                track: unsafe {
-                    mem::transmute::<_,WebmVideoTrackRef>(self.track)
-                },
-                phantom: PhantomData,
-            }),
-            AUDIO_TRACK_TYPE => TrackType::Audio(AudioTrack {
-                track: unsafe {
-                    mem::transmute::<_,WebmAudioTrackRef>(self.track)
-                },
-                phantom: PhantomData,
-            }),
+            VIDEO_TRACK_TYPE => {
+                TrackType::Video(VideoTrack {
+                    track: unsafe {
+                        mem::transmute::<_,WebmVideoTrackRef>(self.track)
+                    },
+                    phantom: PhantomData,
+                })
+            }
+            AUDIO_TRACK_TYPE => {
+                TrackType::Audio(AudioTrack {
+                    track: unsafe {
+                        mem::transmute::<_,WebmAudioTrackRef>(self.track)
+                    },
+                    phantom: PhantomData,
+                })
+            }
             _ => TrackType::Other(self),
         }
     }
@@ -673,21 +677,27 @@ impl<'a> container::Track<'a> for TrackImpl<'a> {
         let reader = self.reader;
         let track = self.track;
         match track.track_type() {
-            TrackType::Video(track) => container::TrackType::Video(Box::new(VideoTrackImpl {
-                track: track,
-                segment: segment,
-                reader: reader,
-            }) as Box<container::VideoTrack<'a> + 'a>),
-            TrackType::Audio(track) => container::TrackType::Audio(Box::new(AudioTrackImpl {
-                track: track,
-                segment: segment,
-                reader: reader,
-            }) as Box<container::AudioTrack<'a> + 'a>),
-            TrackType::Other(track) => container::TrackType::Other(Box::new(TrackImpl {
-                track: track,
-                segment: segment,
-                reader: reader,
-            }) as Box<container::Track<'a> + 'a>),
+            TrackType::Video(track) => {
+                container::TrackType::Video(Box::new(VideoTrackImpl {
+                    track: track,
+                    segment: segment,
+                    reader: reader,
+                }) as Box<container::VideoTrack<'a> + 'a>)
+            }
+            TrackType::Audio(track) => {
+                container::TrackType::Audio(Box::new(AudioTrackImpl {
+                    track: track,
+                    segment: segment,
+                    reader: reader,
+                }) as Box<container::AudioTrack<'a> + 'a>)
+            }
+            TrackType::Other(track) => {
+                container::TrackType::Other(Box::new(TrackImpl {
+                    track: track,
+                    segment: segment,
+                    reader: reader,
+                }) as Box<container::Track<'a> + 'a>)
+            }
         }
     }
     fn is_video(&self) -> bool { self.track.is_video() }

--- a/containers/mkv.rs
+++ b/containers/mkv.rs
@@ -18,15 +18,15 @@ use videodecoder;
 use libc::{c_char, c_double, c_int, c_long, c_longlong, c_uchar, c_ulong, c_void, size_t};
 use std::ffi::CStr;
 use std::mem;
-use std::old_io::SeekStyle;
+use std::io::SeekFrom;
 use std::ptr;
 use std::slice;
 use std::marker::PhantomData;
 
 const VIDEO_TRACK_TYPE: i32 = 1;
 const AUDIO_TRACK_TYPE: i32 = 2;
-// const SUBTITLE_TRACK_TYPE: i32 = 0x11;
-// const METADATA_TRACK_TYPE: i32 = 0x21;
+#[allow(unused)] const SUBTITLE_TRACK_TYPE: i32 = 0x11;
+#[allow(unused)] const METADATA_TRACK_TYPE: i32 = 0x21;
 
 pub struct MkvReader {
     reader: WebmIMkvReaderRef,
@@ -63,10 +63,10 @@ extern "C" fn read_callback(pos: c_longlong,
 
     unsafe {
         let reader: &mut Box<Box<StreamReader>> = mem::transmute(&mut user_data);
-        if reader.seek(pos, SeekStyle::SeekSet).is_err() {
+        if reader.seek(SeekFrom::Start(pos as u64)).is_err() {
             return -1
         }
-        match reader.read_at_least(len as usize, slice::from_raw_parts_mut(buf, len as usize)) {
+        match reader.read(slice::from_raw_parts_mut(buf, len as usize)) {
             Ok(number_read) if number_read == len as usize => 0,
             _ => -1,
         }

--- a/containers/mp4.rs
+++ b/containers/mp4.rs
@@ -18,7 +18,7 @@ use videodecoder;
 use libc::{self, c_char, c_double, c_int, c_long, c_void};
 use std::ffi::{CString, CStr};
 use std::mem;
-use std::old_io::SeekStyle;
+use std::io::SeekFrom;
 use std::ptr;
 use std::slice::bytes;
 use std::slice;
@@ -286,7 +286,7 @@ extern "C" fn file_provider_open(name: *const c_char, _: ffi::MP4FileMode) -> *m
 extern "C" fn file_provider_seek(mut handle: *mut c_void, pos: i64) -> c_int {
     unsafe {
         let reader: &mut Box<Box<StreamReader>> = mem::transmute(&mut handle);
-        if reader.seek(pos, SeekStyle::SeekSet).is_ok() {
+        if reader.seek(SeekFrom::Start(pos as u64)).is_ok() {
             0
         } else {
             1
@@ -306,8 +306,7 @@ extern "C" fn file_provider_read(mut handle: *mut c_void,
 
     unsafe {
         let reader: &mut Box<Box<StreamReader>> = mem::transmute(&mut handle);
-        match reader.read_at_least(size as usize,
-                                   slice::from_raw_parts_mut((buffer as *mut u8), size as usize)) {
+        match reader.read(slice::from_raw_parts_mut((buffer as *mut u8), size as usize)) {
             Ok(number_read) => {
                 *nin = number_read as i64;
                 0

--- a/containers/ogg.rs
+++ b/containers/ogg.rs
@@ -15,6 +15,7 @@ use libc::{c_char, c_int, c_long};
 use std::i32;
 use std::mem;
 use std::slice;
+use std::marker::PhantomData;
 
 pub struct SyncState {
     state: ffi::ogg_sync_state,
@@ -44,7 +45,7 @@ impl SyncState {
         unsafe {
             let ptr = ffi::ogg_sync_buffer(&mut self.state, size);
             assert!(!ptr.is_null());
-            mem::transmute::<&mut [c_char],&'a mut [u8]>(slice::from_raw_mut_buf(&ptr,
+            mem::transmute::<&mut [c_char],&'a mut [u8]>(slice::from_raw_parts_mut(ptr,
                                                                                  size as usize))
         }
     }
@@ -127,12 +128,14 @@ impl StreamState {
         }
         Packet {
             packet: packet,
+            phantom: PhantomData,
         }
     }
 }
 
 pub struct Packet<'a> {
     packet: ffi::ogg_packet,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Packet<'a> {
@@ -153,6 +156,7 @@ impl<'a> Packet<'a> {
                 granulepos: 0,
                 packetno: packet_number,
             },
+            phantom: PhantomData,
         }
     }
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -21,11 +21,9 @@ git = "https://github.com/tomaka/clock_ticks.git"
 [dependencies.sdl2]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
 
 [dependencies.sdl2-sys]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
 path = "sdl2-sys"
 

--- a/example/example.rs
+++ b/example/example.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(collections, core, env, old_io, libc, old_path, rustc_private, std_misc)]
+#![feature(collections, core, old_io, libc, old_path, rustc_private, std_misc)]
 
 extern crate clock_ticks;
 extern crate libc;
@@ -34,7 +34,7 @@ use sdl2::{INIT_AUDIO, INIT_VIDEO, init};
 use std::cmp;
 use std::env;
 use std::mem;
-use std::old_io::fs::File;
+use std::fs::File;
 use std::old_io::timer;
 use std::slice;
 use std::time::duration::Duration;

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor, box_patterns)]
+#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor, box_patterns,
+            unsafe_no_drop_flag, io)]
 
 extern crate alloc;
 extern crate libc;

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, collections, core, io, libc, std_misc, unsafe_destructor)]
+#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor)]
 
 extern crate alloc;
 extern crate libc;

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor)]
+#![feature(alloc, collections, core, old_io, libc, std_misc, unsafe_destructor, box_patterns)]
 
 extern crate alloc;
 extern crate libc;

--- a/playback.rs
+++ b/playback.rs
@@ -53,9 +53,9 @@ impl<'a> Player<'a> {
             let (mut video_track, mut audio_track) = (None, None);
             for track_index in 0..reader.track_count() {
                 let track = reader.track_by_index(track_index);
-                if track.track_type() == TrackType::Video && video_track.is_none() {
+                if track.is_video() && video_track.is_none() {
                     video_track = Some(track)
-                } else if track.track_type() == TrackType::Audio && audio_track.is_none() {
+                } else if track.is_audio() && audio_track.is_none() {
                     audio_track = Some(track)
                 }
             }
@@ -90,15 +90,30 @@ impl<'a> Player<'a> {
     }
 
     pub fn decode_frame(&mut self) -> Result<(),()> {
+        // This code abuses Box's magic ownership to get audio and video tracks
+        // without borrowing self. This is why we just inline the code from those
+        // methods.
+
         let reader = &mut *self.reader;
+
         let video_track = self.video.as_ref().map(|video| {
-            reader.track_by_number(video.track_number as c_long)
+            let number = video.track_number;
+            if let TrackType::Video(track) = reader.track_by_number(number).track_type() {
+                track
+            } else {
+                unreachable!()
+            }
         });
-        let video_track = video_track.as_ref().map(|track| track.as_video_track().unwrap());
+
         let audio_track = self.audio.as_ref().map(|audio| {
-            reader.track_by_number(audio.track_number as c_long)
+            let number = audio.track_number;
+            if let TrackType::Audio(track) = reader.track_by_number(number).track_type() {
+                track
+            } else {
+                unreachable!()
+            }
         });
-        let audio_track = audio_track.as_ref().map(|track| track.as_audio_track().unwrap());
+
         'clusterloop: loop {
             let cluster = match (&video_track, &audio_track) {
                 (&Some(ref video_track), _) => {
@@ -215,14 +230,26 @@ impl<'a> Player<'a> {
         }
     }
 
-    /// Returns the number of the video track, if present.
-    pub fn video_track_number(&self) -> Option<i64> {
-        self.video.as_ref().map(|video| video.track_number)
+    pub fn video_track<'b>(&'b self) -> Option<Box<VideoTrack + 'b>> {
+        self.video.as_ref().map(|video| {
+            let number = video.track_number;
+            if let TrackType::Video(track) = self.reader.track_by_number(number).track_type() {
+                track
+            } else {
+                unreachable!()
+            }
+        })
     }
 
-    /// Returns the number of the audio track, if present.
-    pub fn audio_track_number(&self) -> Option<i64> {
-        self.audio.as_ref().map(|audio| audio.track_number)
+    pub fn audio_track<'b>(&'b self) -> Option<Box<AudioTrack + 'b>> {
+        self.audio.as_ref().map(|audio| {
+            let number = audio.track_number;
+            if let TrackType::Audio(track) = self.reader.track_by_number(number).track_type() {
+                track
+            } else {
+                unreachable!()
+            }
+        })
     }
 
     /// Returns the presentation time of the last frame, relative to the start of playback.
@@ -308,21 +335,19 @@ fn read_track_metadata_and_initialize_codecs(reader: &mut ContainerReader)
     for track_index in 0..reader.track_count() {
         let track = reader.track_by_index(track_index);
         match track.track_type() {
-            TrackType::Video => {
-                let video_track = track.as_video_track().unwrap();
+            TrackType::Video(video_track) => {
                 if let Some(codec) = video_track.codec() {
                     let headers = video_track.headers();
-                    video_codec = Some(RegisteredVideoDecoder::get(codec.as_slice()).unwrap().new(
+                    video_codec = Some(RegisteredVideoDecoder::get(&codec).unwrap().new(
                             &*headers,
                             video_track.width() as i32,
                             video_track.height() as i32).unwrap());
                 }
             }
-            TrackType::Audio => {
-                let audio_track = track.as_audio_track().unwrap();
+            TrackType::Audio(audio_track) => {
                 if let Some(codec) = audio_track.codec() {
                     let headers = audio_track.headers();
-                    let info = RegisteredAudioDecoder::get(codec.as_slice()).unwrap().new(
+                    let info = RegisteredAudioDecoder::get(&codec).unwrap().new(
                             &*headers,
                             audio_track.sampling_rate(),
                             audio_track.channels());

--- a/playback.rs
+++ b/playback.rs
@@ -18,6 +18,7 @@ use libc::{c_int, c_long};
 use std::iter;
 use std::mem;
 use std::num::SignedInt;
+use std::marker::PhantomData;
 
 /// A simple video/audio player.
 pub struct Player<'a> {
@@ -36,6 +37,7 @@ pub struct Player<'a> {
     last_frame_presentation_time: Option<Timestamp>,
     /// The time at which the next frame is to be played.
     next_frame_presentation_time: Option<Timestamp>,
+    phantom: PhantomData<&'a u8>,
 }
 
 impl<'a> Player<'a> {
@@ -83,6 +85,7 @@ impl<'a> Player<'a> {
             frame_delay: None,
             last_frame_presentation_time: None,
             next_frame_presentation_time: None,
+            phantom: PhantomData,
         }
     }
 
@@ -231,7 +234,7 @@ impl<'a> Player<'a> {
     pub fn next_frame_presentation_time(&self) -> Option<Timestamp> {
         self.next_frame_presentation_time
     }
-    
+
     /// Retrieves the decoded frame data and advances to the next frame.
     pub fn advance(&mut self) -> Result<DecodedFrame,()> {
         // Determine the frame delay, if possible.

--- a/streaming.rs
+++ b/streaming.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io::fs::File;
-use std::old_io::{Reader, Seek};
+use std::fs::File;
+use std::io::{Read, Seek};
 
-pub trait StreamReader : Reader + Seek {
+pub trait StreamReader : Read + Seek {
     /// Returns the number of bytes available in this stream.
     fn available_size(&self) -> u64;
     /// Returns the total number of octets in this stream, including those that are not yet
@@ -25,7 +25,7 @@ impl StreamReader for File {
         self.total_size()
     }
     fn total_size(&self) -> u64 {
-        self.stat().unwrap().size
+       self.metadata().unwrap().len()
     }
 }
 


### PR DESCRIPTION
This is built on top of #14, with the newest commit being the new change.

This merges the Track::track_type and Track::as_video_track functionality into a single method that returns a tagged union. The end result is that clients have to write less boiler-plate, and the API is more type-safe.

There were some speed-bumps in doing this, though. It turns out that the separation of functionality was _necessary_ in the old design to ensure that all the necessary temporaries were alive. However after observing the current concrete implementations, it appeared that this wasn't necessary. Every single concrete implementation was basically cloning self into a type with identical repr.

As such Track::track_type has been changed to take `Box<Self>`. This has two benefits: it moves self into the function, removing any need for the resultant cast to have a "reference" to the parent; and it allows the allocation from the original to be _reused_. In fact in principle all of the impls could basically be replaced with a match where every branch transmutes the Box.

However to accomplish this Track, AudioTrack, and VideoTrack needed to acquire a lifetime parameter. This is basically fine, since they're always intended to be behind a Box anyway.

As a consequence, the impl TrackExt is busted because it wants to peek into what type each track is temporarily, but this is not a consuming operation.

Also mixed in are some random cleanups.
