### PR TITLE
Update to rust 1.14 nightly and update the example dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Rust related files
+/Cargo.lock
+target/
+
+# Editor temporary files
+*swp

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Other design goals include:
 * Scale up to hundreds of videos playing simultaneously.
 
   - Leave thread management up to the user of the library; don't require that playback happen on a dedicated thread.
-  
+
 * Use hardware decoders where available.
 
 * Be easy to use.
@@ -45,15 +45,11 @@ Other design goals include:
     $ cd example
     $ cargo build
 
-This will probably fail with an error about `#[derive(Copy)]` in `libc`. You will need to edit the `Cargo.lock` file and change references from `0.1.2` of `libc` to `0.1.1`. Then rerun `cargo build`:
-
-    $ cargo build
-
 ## Try out the example
 
 * Play a WebM video:
 
-        $ target/release/example ~/Movies/big_buck_bunny_480p.webm video/webm
+        $ cargo run ~/Movies/big_buck_bunny_480p.webm video/webm
 
 * Play a YouTube video:
 

--- a/codecs/libavcodec.rs
+++ b/codecs/libavcodec.rs
@@ -171,7 +171,7 @@ impl AvCodecContext {
     }
 
     pub fn get_double_opt(&self, name: &[u8]) -> Result<c_double,c_int> {
-        let name = CString::from_slice(name);
+        let name = unsafe { CString::from_vec_unchecked(name.into()) };
         let mut out_val = 0.0;
         let result = unsafe {
             ffi::av_opt_get_double(self.context.ptr() as *mut c_void,
@@ -187,7 +187,7 @@ impl AvCodecContext {
     }
 
     pub fn get_q_opt(&self, name: &[u8]) -> Result<ffi::AVRational,c_int> {
-        let name = CString::from_slice(name);
+        let name = unsafe { CString::from_vec_unchecked(name.into()) };
         let mut out_val = ffi::AVRational {
             num: 0,
             den: 0,
@@ -324,7 +324,7 @@ impl AvFrame {
     pub fn video_data<'a>(&'a self, plane_index: usize) -> &'a [u8] {
         let len = self.linesize(plane_index) * self.height();
         unsafe {
-            slice::from_raw_mut_buf(&(*self.frame).data[plane_index], len as usize)
+            slice::from_raw_parts(*&(*self.frame).data[plane_index], len as usize)
         }
     }
 
@@ -335,13 +335,14 @@ impl AvFrame {
                                        true).unwrap()
                                             .linesize;
         unsafe {
-            slice::from_raw_mut_buf(&(*self.frame).data[channel], len as usize)
+            slice::from_raw_parts(*&(*self.frame).data[channel], len as usize)
         }
     }
 }
 
 pub struct AvPacket<'a> {
     packet: ffi::EitherAVPacket,
+    phantom: ::std::marker::PhantomData<&'a[u8]>,
 }
 
 impl<'a> AvPacket<'a> {
@@ -350,7 +351,7 @@ impl<'a> AvPacket<'a> {
         // Guard against segfaults per the documentation by setting the padding to zero.
         assert!(data.len() <= (i32::MAX as usize));
         assert!(data.len() >= FF_INPUT_BUFFER_PADDING_SIZE);
-        for i in range(data.len() - FF_INPUT_BUFFER_PADDING_SIZE, data.len()) {
+        for i in data.len() - FF_INPUT_BUFFER_PADDING_SIZE..data.len() {
             data[i] = 0
         }
 
@@ -377,6 +378,7 @@ impl<'a> AvPacket<'a> {
 
         AvPacket {
             packet: packet,
+            phantom: ::std::marker::PhantomData,
         }
     }
 }
@@ -402,8 +404,8 @@ impl AvDictionary {
 
     pub fn set(&mut self, key: &str, value: &str) {
         unsafe {
-            let key = CString::from_slice(key.as_bytes());
-            let value = CString::from_slice(value.as_bytes());
+            let key = unsafe { CString::from_vec_unchecked(key.into()) };
+            let value = unsafe { CString::from_vec_unchecked(value.into()) };
             assert!(ffi::av_dict_set(&mut self.dictionary, key.as_ptr(), value.as_ptr(), 0) >= 0);
         }
     }
@@ -414,7 +416,7 @@ pub mod samples {
 
     use libc::c_int;
 
-    #[derive(Copy)]
+    #[derive(Clone, Copy)]
     pub struct BufferSizeResult {
         pub buffer_size: c_int,
         pub linesize: c_int,
@@ -472,13 +474,13 @@ impl videodecoder::VideoDecoder for VideoDecoderImpl {
     fn decode_frame(&self, data: &[u8], presentation_time: &Timestamp)
                     -> Result<Box<videodecoder::DecodedVideoFrame + 'static>,()> {
         let mut data: Vec<_> = data.iter().map(|x| *x).collect();
-        for _ in range(0, FF_INPUT_BUFFER_PADDING_SIZE) {
+        for _ in 0..FF_INPUT_BUFFER_PADDING_SIZE {
             data.push(0);
         }
 
         let mut packet = AvPacket::new(data.as_mut_slice());
-        let presentation_time = *presentation_time;
-        self.context.borrow_mut().set_get_buffer_callback(Box::new(|frame: &AvFrame| {
+        let presentation_time = presentation_time.clone();
+        self.context.borrow_mut().set_get_buffer_callback(Box::new(move |frame: &AvFrame| {
             frame.set_user_data(Box::new(presentation_time))
         }));
 
@@ -567,8 +569,8 @@ impl audiodecoder::AudioDecoderInfo for AudioDecoderInfoImpl {
         let codec = AvCodec::find_decoder(AV_CODEC_ID_AAC).unwrap();
         let context = AvCodecContext::new(&codec);
         let mut options = AvDictionary::new();
-        options.set("ac", self.channels.to_string().as_slice());
-        options.set("ar", self.sample_rate.to_string().as_slice());
+        options.set("ac", &self.channels.to_string());
+        options.set("ar", &self.sample_rate.to_string());
         options.set("request_sample_fmt", "fltp");
 
         let (result, _) = context.open(&codec, options);
@@ -589,7 +591,7 @@ impl audiodecoder::AudioDecoder for AudioDecoderImpl {
     fn decode(&mut self, data: &[u8]) -> Result<(),()> {
         let data_len = data.len();
         let mut data: Vec<_> = data.iter().map(|x| *x).collect();
-        for _ in range(0, FF_INPUT_BUFFER_PADDING_SIZE) {
+        for _ in 0..FF_INPUT_BUFFER_PADDING_SIZE {
             data.push(0);
         }
         let mut packet = AvPacket::new(data.as_mut_slice());
@@ -632,9 +634,8 @@ impl<'a> audiodecoder::DecodedAudioSamples for DecodedAudioSamplesImpl<'a> {
         let data = self.frame.audio_data(channel as usize, self.channels);
         unsafe {
             Some(mem::transmute::<&[f32],
-                                  &'b [f32]>(slice::from_raw_buf(&(data.as_ptr() as *const f32),
-                                                                 data.len() /
-                                                                    mem::size_of::<f32>())))
+                                  &'b [f32]>(slice::from_raw_parts(data.as_ptr() as *const f32,
+                                                                   data.len() / mem::size_of::<f32>())))
         }
     }
 }
@@ -1069,7 +1070,7 @@ pub mod ffi {
     }
 
     #[repr(C)]
-    #[derive(Copy, Debug)]
+    #[derive(Clone, Copy, Debug)]
     pub struct AVRational {
         pub num: c_int,
         pub den: c_int,

--- a/codecs/libavcodec.rs
+++ b/codecs/libavcodec.rs
@@ -21,6 +21,7 @@ use std::cell::RefCell;
 use std::ffi::CString;
 use std::i32;
 use std::mem;
+use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
 
@@ -342,7 +343,7 @@ impl AvFrame {
 
 pub struct AvPacket<'a> {
     packet: ffi::EitherAVPacket,
-    phantom: ::std::marker::PhantomData<&'a[u8]>,
+    phantom: PhantomData<&'a [u8]>,
 }
 
 impl<'a> AvPacket<'a> {
@@ -378,7 +379,7 @@ impl<'a> AvPacket<'a> {
 
         AvPacket {
             packet: packet,
-            phantom: ::std::marker::PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -2,7 +2,6 @@
 name = "rust-media-example"
 version = "0.1.0"
 dependencies = [
- "clock_ticks 0.1.0 (git+https://github.com/tomaka/clock_ticks.git)",
  "rust-media 0.1.0",
  "sdl2 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)",
 ]
@@ -16,11 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "clock_ticks"
-version = "0.1.0"
-source = "git+https://github.com/tomaka/clock_ticks.git#34239b132f9c6e5c34b1280df272e6fd0772270e"
 
 [[package]]
 name = "core-foundation"
@@ -236,7 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-"checksum clock_ticks 0.1.0 (git+https://github.com/tomaka/clock_ticks.git)" = "<none>"
 "checksum core-foundation 0.2.2 (git+https://github.com/servo/rust-core-foundation)" = "<none>"
 "checksum core-foundation-sys 0.2.2 (git+https://github.com/servo/rust-core-foundation)" = "<none>"
 "checksum giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)" = "<none>"

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -1,0 +1,265 @@
+[root]
+name = "rust-media-example"
+version = "0.1.0"
+dependencies = [
+ "clock_ticks 0.1.0 (git+https://github.com/tomaka/clock_ticks.git)",
+ "rust-media 0.1.0",
+ "sdl2 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clock_ticks"
+version = "0.1.0"
+source = "git+https://github.com/tomaka/clock_ticks.git#34239b132f9c6e5c34b1280df272e6fd0772270e"
+
+[[package]]
+name = "core-foundation"
+version = "0.2.2"
+source = "git+https://github.com/servo/rust-core-foundation#2806eb863a1e18c7c0a6598c946dfaf69923b2f9"
+dependencies = [
+ "core-foundation-sys 0.2.2 (git+https://github.com/servo/rust-core-foundation)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.2"
+source = "git+https://github.com/servo/rust-core-foundation#2806eb863a1e18c7c0a6598c946dfaf69923b2f9"
+dependencies = [
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "giflib-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/giflib#6f3682de31b80d79429edcb8538082908b99331e"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libvpx-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libvpx?branch=servo#3492c9d01dad901e6ba61e26bdb3bb817799db21"
+
+[[package]]
+name = "libwebm-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libwebm?branch=servo#a730c14fab6f39784bdacf25afdfa6e99cbbce9b"
+
+[[package]]
+name = "mp4v2-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/mp4v2?branch=servo#a6d29cd629e1021cc520c5a27fb873c231f5968a"
+
+[[package]]
+name = "num"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-macros"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-rational"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ogg-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/ogg?branch=servo#c6b10c9b337bb68596f9c096c087f657b3b26ab5"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-media"
+version = "0.1.0"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.2.2 (git+https://github.com/servo/rust-core-foundation)",
+ "giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)",
+ "libvpx-sys 0.1.0 (git+https://github.com/pcwalton/libvpx?branch=servo)",
+ "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
+ "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-macros 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vorbis-sys 0.1.0 (git+https://github.com/pcwalton/vorbis?branch=servo)",
+]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sdl2"
+version = "0.24.0"
+source = "git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510#62e08b3d4d0a043215165231cd093964260c4510"
+dependencies = [
+ "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)",
+]
+
+[[package]]
+name = "sdl2-sys"
+version = "0.24.0"
+source = "git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510#62e08b3d4d0a043215165231cd093964260c4510"
+dependencies = [
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vorbis-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/vorbis?branch=servo#82aaf9791bb25b42ca81d0f4055fc767bab441cd"
+dependencies = [
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum clock_ticks 0.1.0 (git+https://github.com/tomaka/clock_ticks.git)" = "<none>"
+"checksum core-foundation 0.2.2 (git+https://github.com/servo/rust-core-foundation)" = "<none>"
+"checksum core-foundation-sys 0.2.2 (git+https://github.com/servo/rust-core-foundation)" = "<none>"
+"checksum giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)" = "<none>"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
+"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum libvpx-sys 0.1.0 (git+https://github.com/pcwalton/libvpx?branch=servo)" = "<none>"
+"checksum libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)" = "<none>"
+"checksum mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)" = "<none>"
+"checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
+"checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
+"checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
+"checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
+"checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
+"checksum num-macros 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "260f43d0e7e6bb0d4360f356a45a5f53fd4153ef1583b656b6ff35b7dae9cf0a"
+"checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)" = "<none>"
+"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum sdl2 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)" = "<none>"
+"checksum sdl2-sys 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)" = "<none>"
+"checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
+"checksum vorbis-sys 0.1.0 (git+https://github.com/pcwalton/vorbis?branch=servo)" = "<none>"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -21,11 +21,4 @@ git = "https://github.com/tomaka/clock_ticks.git"
 [dependencies.sdl2]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
-
-[dependencies.sdl2-sys]
-
-git = "https://github.com/AngryLawyer/rust-sdl2"
-rev = "a36627dff1069e5ca6098dd3a39fbd6039794097"
-path = "sdl2-sys"
-
+rev = "62e08b3d4d0a043215165231cd093964260c4510"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,10 +14,6 @@ path = "example.rs"
 path = ".."
 features = ["ffmpeg"]
 
-[dependencies.clock_ticks]
-
-git = "https://github.com/tomaka/clock_ticks.git"
-
 [dependencies.sdl2]
 
 git = "https://github.com/AngryLawyer/rust-sdl2"

--- a/example/example.rs
+++ b/example/example.rs
@@ -9,7 +9,6 @@
 
 #![feature(collections, core, env, io, libc, os, path, rustc_private, std_misc)]
 
-extern crate clock_ticks;
 extern crate libc;
 extern crate rust_media as media;
 extern crate sdl2;
@@ -39,26 +38,26 @@ use std::mem;
 use std::fs::File;
 use std::thread::sleep;
 use std::slice;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 struct ExampleMediaPlayer {
     /// A reference timestamp at which playback began.
     playback_start_ticks: i64,
     /// A reference time in nanoseconds at which playback began.
-    playback_start_wallclock_time: u64,
+    playback_start_wallclock_time: Instant,
 }
 
 impl ExampleMediaPlayer {
     fn new() -> ExampleMediaPlayer {
         ExampleMediaPlayer {
             playback_start_ticks: 0,
-            playback_start_wallclock_time: clock_ticks::precise_time_ns(),
+            playback_start_wallclock_time: Instant::now(),
         }
     }
 
     fn resync(&mut self, ticks: i64) {
         self.playback_start_ticks = ticks;
-        self.playback_start_wallclock_time = clock_ticks::precise_time_ns()
+        self.playback_start_wallclock_time = Instant::now();
     }
 
     /// Polls events so we can quit if the user wanted to. Returns true to continue or false to
@@ -345,9 +344,9 @@ fn main() {
 
         let target_time_since_playback_start = (player.next_frame_presentation_time().unwrap() -
                                                 media_player.playback_start_ticks).duration();
-        let target_time = Duration::new(0, media_player.playback_start_wallclock_time as u32)
+        let target_time = media_player.playback_start_wallclock_time
             + target_time_since_playback_start.to_std().unwrap();
-        sleep(target_time - Duration::new(0, clock_ticks::precise_time_ns() as u32));
+        sleep(target_time - Instant::now());
 
         let frame = match player.advance() {
             Ok(frame) => frame,

--- a/example/example.rs
+++ b/example/example.rs
@@ -346,7 +346,10 @@ fn main() {
                                                 media_player.playback_start_ticks).duration();
         let target_time = media_player.playback_start_wallclock_time
             + target_time_since_playback_start.to_std().unwrap();
-        sleep(target_time - Instant::now());
+        let now = Instant::now();
+        if now < target_time {
+            sleep(target_time - now);
+        }
 
         let frame = match player.advance() {
             Ok(frame) => frame,

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, libc, unsafe_no_drop_flag, custom_derive, plugin)]
+#![feature(alloc, libc, custom_derive, plugin)]
 #![feature(heap_api)]
 #![plugin(num_macros)]
 

--- a/playback.rs
+++ b/playback.rs
@@ -40,6 +40,7 @@ pub struct Player<'a> {
     marker: PhantomData<&'a ()>,
 }
 
+#[derive(Debug)]
 pub enum PlayerCreationError {
     NoRegisteredContainer,
     ContainerCreation,
@@ -245,7 +246,7 @@ impl<'a> Player<'a> {
     pub fn next_frame_presentation_time(&self) -> Option<Timestamp> {
         self.next_frame_presentation_time
     }
-    
+
     /// Retrieves the decoded frame data and advances to the next frame.
     pub fn advance(&mut self) -> Result<DecodedFrame,()> {
         // Determine the frame delay, if possible.


### PR DESCRIPTION
- Add a gitignore to make working with the repo easier
- Update the example to use the latest sdl. Also update its Cargo.toml to reflect the change.
- Remove use of the deprecated clock_ticks crate.

I have tested the example, and playback of webm is working well.
