### PR TITLE
Build fixes + track stabilisation of proc_macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ git = "https://github.com/servo/rust-core-foundation"
 
 [dependencies]
 num = "*"
-num-derive = "*"
+num-derive = "0.1.38"
 time = "*"
 byteorder = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ git = "https://github.com/servo/rust-core-foundation"
 
 [dependencies]
 num = "*"
-num-derive = "0.1.38"
+num-derive = "0.1.39"
 time = "*"
 byteorder = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ git = "https://github.com/servo/rust-core-foundation"
 
 [dependencies]
 num = "*"
-num-macros = "*"
+num-derive = "*"
 time = "*"
 byteorder = "*"
 

--- a/audiodecoder.rs
+++ b/audiodecoder.rs
@@ -18,8 +18,12 @@ use codecs::libavcodec;
 use platform;
 
 pub trait AudioHeaders {
-    fn vorbis_headers<'a>(&'a self) -> Option<&'a VorbisHeaders>;
-    fn aac_headers<'a>(&'a self) -> Option<&'a AacHeaders>;
+    fn vorbis_headers<'a>(&'a self) -> Option<&'a VorbisHeaders> {
+        None
+    }
+    fn aac_headers<'a>(&'a self) -> Option<&'a AacHeaders> {
+        None
+    }
 }
 
 pub trait AudioDecoderInfo {
@@ -40,14 +44,7 @@ pub trait DecodedAudioSamples {
 #[derive(Copy, Clone)]
 pub struct EmptyAudioHeadersImpl;
 
-impl AudioHeaders for EmptyAudioHeadersImpl {
-    fn vorbis_headers<'a>(&'a self) -> Option<&'a VorbisHeaders> {
-        None
-    }
-    fn aac_headers<'a>(&'a self) -> Option<&'a AacHeaders> {
-        None
-    }
-}
+impl AudioHeaders for EmptyAudioHeadersImpl {}
 
 #[allow(missing_copy_implementations)]
 pub struct RegisteredAudioDecoder {

--- a/audiodecoder.rs
+++ b/audiodecoder.rs
@@ -76,27 +76,14 @@ impl RegisteredAudioDecoder {
     }
 }
 
-#[cfg(all(target_os="macos", feature="ffmpeg"))]
-pub static AUDIO_DECODERS: [RegisteredAudioDecoder; 3] = [
+pub static AUDIO_DECODERS: [RegisteredAudioDecoder;
+    1 +
+    cfg!(target_os="macos") as usize +
+    cfg!(feature="ffmpeg") as usize
+] = [
     vorbis::AUDIO_DECODER,
-    libavcodec::AUDIO_DECODER,
+    #[cfg(target_os="macos")]
     platform::macos::audiounit::AUDIO_DECODER,
-];
-
-#[cfg(all(target_os="macos", not(feature="ffmpeg")))]
-pub static AUDIO_DECODERS: [RegisteredAudioDecoder; 2] = [
-    vorbis::AUDIO_DECODER,
-    platform::macos::audiounit::AUDIO_DECODER,
-];
-
-#[cfg(all(not(target_os="macos"), feature="ffmpeg"))]
-pub static AUDIO_DECODERS: [RegisteredAudioDecoder; 2] = [
-    vorbis::AUDIO_DECODER,
+    #[cfg(feature="ffmpeg")]
     libavcodec::AUDIO_DECODER,
 ];
-
-#[cfg(all(not(target_os="macos"), not(feature="ffmpeg")))]
-pub static AUDIO_DECODERS: [RegisteredAudioDecoder; 1] = [
-    vorbis::AUDIO_DECODER,
-];
-

--- a/codecs/aac.rs
+++ b/codecs/aac.rs
@@ -8,16 +8,12 @@
 // except according to those terms.
 
 use audiodecoder::AudioHeaders;
-use codecs::vorbis::VorbisHeaders;
 
 pub struct AacHeaders {
     pub esds_chunk: Vec<u8>,
 }
 
 impl AudioHeaders for AacHeaders {
-    fn vorbis_headers<'a>(&'a self) -> Option<&'a VorbisHeaders> {
-        None
-    }
     fn aac_headers<'a>(&'a self) -> Option<&'a AacHeaders> {
         Some(self)
     }

--- a/codecs/vorbis.rs
+++ b/codecs/vorbis.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 use audiodecoder;
-use codecs::aac::AacHeaders;
 
 use libc::{c_int};
 
@@ -63,9 +62,6 @@ impl VorbisHeaders {
 impl audiodecoder::AudioHeaders for VorbisHeaders {
     fn vorbis_headers<'a>(&'a self) -> Option<&'a VorbisHeaders> {
         Some(self)
-    }
-    fn aac_headers<'a>(&'a self) -> Option<&'a AacHeaders> {
-        None
     }
 }
 

--- a/containers/gif.rs
+++ b/containers/gif.rs
@@ -440,7 +440,7 @@ impl GraphicsControlBlock {
 }
 
 #[repr(i32)]
-#[derive(Copy, Clone, NumFromPrimitive)]
+#[derive(Copy, Clone, FromPrimitive)]
 pub enum DisposalMode {
     Unspecified = 0,
     DoNot = 1,

--- a/containers/mkv.rs
+++ b/containers/mkv.rs
@@ -613,7 +613,8 @@ impl<'a> BlockFrame<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, NumFromPrimitive, PartialEq)]
+#[proc_macro_derive(FromPrimitive)]
+#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
 pub enum TrackType {
     Video = 1,
     Audio = 2,

--- a/containers/mkv.rs
+++ b/containers/mkv.rs
@@ -613,7 +613,6 @@ impl<'a> BlockFrame<'a> {
     }
 }
 
-#[proc_macro_derive(FromPrimitive)]
 #[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
 pub enum TrackType {
     Video = 1,

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,7 +191,7 @@ dependencies = [
  "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
  "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
  "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
 "checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
-"checksum num-derive 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "251e0b3a96963b6dbd140b57b67292174f095400f9650c419be414c6416d88d8"
+"checksum num-derive 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "88bec4baca6ed7b5900428e98532d2ac8c4ac242f5460425a90676f85e19b40d"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,11 +144,6 @@ dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "num-macros"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-rational"
@@ -163,6 +167,11 @@ version = "0.1.0"
 source = "git+https://github.com/pcwalton/ogg?branch=servo#c6b10c9b337bb68596f9c096c087f657b3b26ab5"
 
 [[package]]
+name = "quote"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +191,7 @@ dependencies = [
  "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
  "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
  "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-macros 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -211,6 +220,14 @@ version = "0.24.0"
 source = "git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510#62e08b3d4d0a043215165231cd093964260c4510"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -250,16 +267,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
 "checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
+"checksum num-derive 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "251e0b3a96963b6dbd140b57b67292174f095400f9650c419be414c6416d88d8"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
-"checksum num-macros 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "260f43d0e7e6bb0d4360f356a45a5f53fd4153ef1583b656b6ff35b7dae9cf0a"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)" = "<none>"
+"checksum quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b0f1847d90ff21d41b08f7f9f8e82dff613c3e2c5ebc9f8a10aeee1a0c4d7d17"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum sdl2 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)" = "<none>"
 "checksum sdl2-sys 0.24.0 (git+https://github.com/AngryLawyer/rust-sdl2?rev=62e08b3d4d0a043215165231cd093964260c4510)" = "<none>"
+"checksum syn 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d25c61533bd33b0badb0b96178731a19407586f8a2547753095109c142e5242"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.1.38"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,7 +191,7 @@ dependencies = [
  "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
  "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
  "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
 "checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
-"checksum num-derive 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "88bec4baca6ed7b5900428e98532d2ac8c4ac242f5460425a90676f85e19b40d"
+"checksum num-derive 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "c8bdc32450baf46be50a6dc8e9f70916c93142100841545c6810dbda5d79eaa6"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, libc, proc_macro)]
+#![feature(alloc, libc)]
 
 extern crate alloc;
 extern crate byteorder;

--- a/lib.rs
+++ b/lib.rs
@@ -7,13 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, libc, custom_derive, plugin)]
-#![plugin(num_macros)]
+#![feature(alloc, libc, proc_macro)]
 
 extern crate alloc;
 extern crate byteorder;
 extern crate libc;
 extern crate num;
+#[macro_use]
+extern crate num_derive;
 extern crate time;
 
 extern crate lewton;

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -4,7 +4,7 @@ AR ?= ar
 SRC = mkvparser.cpp
 OBJS = $(SRC:%.cpp=$(OUT_DIR)/%.o)
 
-LIBWEBM_OUTDIR ?= $(shell find $(OUT_DIR)/../.. -name 'libwebm-*' '(' -type d -or -type l ')')/out
+LIBWEBM_OUTDIR ?= $(shell find $(OUT_DIR)/../.. -name 'mkvparser.hpp' '(' -type f -or -type l ')' -exec dirname {} \; | grep libwebm)
 
 CXXFLAGS += -std=gnu++11 -Wall -I$(LIBWEBM_OUTDIR) -O2 -fPIC
 

--- a/videodecoder.rs
+++ b/videodecoder.rs
@@ -23,8 +23,12 @@ pub trait VideoDecoder {
 }
 
 pub trait VideoHeaders {
-    fn h264_seq_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>>;
-    fn h264_pict_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>>;
+    fn h264_seq_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>> {
+        None
+    }
+    fn h264_pict_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>> {
+        None
+    }
 }
 
 pub trait DecodedVideoFrame {
@@ -44,15 +48,7 @@ pub trait DecodedVideoFrameLockGuard {
 #[derive(Copy, Clone)]
 pub struct EmptyVideoHeadersImpl;
 
-impl VideoHeaders for EmptyVideoHeadersImpl {
-    fn h264_seq_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>> {
-        None
-    }
-
-    fn h264_pict_headers<'a>(&'a self) -> Option<Vec<&'a [u8]>> {
-        None
-    }
-}
+impl VideoHeaders for EmptyVideoHeadersImpl {}
 
 #[allow(missing_copy_implementations)]
 pub struct RegisteredVideoDecoder {

--- a/videodecoder.rs
+++ b/videodecoder.rs
@@ -81,33 +81,15 @@ impl RegisteredVideoDecoder {
     }
 }
 
-// FIXME(pcwalton): Combinatorial explosion imminent. :( Can we do something clever with macros?
-
-#[cfg(all(target_os="macos", feature="ffmpeg"))]
-pub static VIDEO_DECODERS: [RegisteredVideoDecoder; 4] = [
+pub static VIDEO_DECODERS: [RegisteredVideoDecoder;
+    2 +
+    cfg!(target_os="macos") as usize +
+    cfg!(feature="ffmpeg") as usize
+] = [
     vpx::VIDEO_DECODER,
     gif::VIDEO_DECODER,
-    libavcodec::VIDEO_DECODER,
+    #[cfg(target_os="macos")]
     platform::macos::videotoolbox::VIDEO_DECODER,
-];
-
-#[cfg(all(target_os="macos", not(feature="ffmpeg")))]
-pub static VIDEO_DECODERS: [RegisteredVideoDecoder; 3] = [
-    vpx::VIDEO_DECODER,
-    gif::VIDEO_DECODER,
-    platform::macos::videotoolbox::VIDEO_DECODER,
-];
-
-#[cfg(all(not(target_os="macos"), feature="ffmpeg"))]
-pub static VIDEO_DECODERS: [RegisteredVideoDecoder; 3] = [
-    vpx::VIDEO_DECODER,
-    gif::VIDEO_DECODER,
+    #[cfg(feature="ffmpeg")]
     libavcodec::VIDEO_DECODER,
 ];
-
-#[cfg(all(not(target_os="macos"), not(feature="ffmpeg")))]
-pub static VIDEO_DECODERS: [RegisteredVideoDecoder; 2] = [
-    vpx::VIDEO_DECODER,
-    gif::VIDEO_DECODER,
-];
-


### PR DESCRIPTION
PR with some smaller changes I did locally over time. Wanted to file a PR before they got too old. Includes commits to use the now stable `proc_macro`, and some change in cargo where it changed paths (this is the build fix part, see the "More robust search ..." commit for the change). Also, the PR includes some cosmetic changes to improve the code quality.